### PR TITLE
Use bash `set -o allexport` to export from plain `VAR=value` file

### DIFF
--- a/roles/common/templates/bash_profile
+++ b/roles/common/templates/bash_profile
@@ -1,1 +1,3 @@
+set -o allexport
 . /etc/default/coopdevs
+set +o allexport

--- a/roles/common/templates/secret_coopdevs.j2
+++ b/roles/common/templates/secret_coopdevs.j2
@@ -1,1 +1,1 @@
-export SECRET_KEY_BASE=kaka
+SECRET_KEY_BASE=kaka


### PR DESCRIPTION
# WHY?

An `env` file should contain only key/value pairs, not the `export` keyword. This way it can be used wherever a set of variable can be used.

If on the other side it contains the `export` keyword, it can only ever be used in a shell script.

Some examples of places where a simple `KEY=value` file can be used:
- systemd units, in the `EnvironmentFile` configuration.
- `env $(cat myenvfile) program` -- apply the env only to the program, don't pollute shell.
- any script that can parse files and should not bother about weird `export` strings -- just convert the file into a ruby hash using

``` ruby
env_hash = Hash[open(myenvfile).map { |line| line.split("=", 2) }]
```
# HOW?

To keep the specific env file loaded in a shell, just use `set -o allexport` or the shorter `set -a` just before sourcing the file.
