### PR TITLE
Use `git clone --shared` and avoid almost all filesystem work on deploy

### DIFF
--- a/roles/coopdevs.org/files/post-receive
+++ b/roles/coopdevs.org/files/post-receive
@@ -3,7 +3,7 @@ GIT_REPO=$HOME/repos/coopdevs.github.io.git
 TMP_GIT_CLONE=$HOME/tmp/git/coopdevs.github.io
 PUBLIC_WWW=/opt/sites/coopdevs
 
-git clone $GIT_REPO $TMP_GIT_CLONE
+git clone --shared $GIT_REPO $TMP_GIT_CLONE
 jekyll build --source $TMP_GIT_CLONE --destination $PUBLIC_WWW
 rm -Rf $TMP_GIT_CLONE
 exit


### PR DESCRIPTION
# WHY?

Cloning a local repository, even if better than cloning remote, in that objects are hardlinked between both repoistories, implies a lot of hardlinks to be created. Using `--depth 1` slightly alleviates this, but it is still not a solution.
# HOW?

Just use the `--shared` flag, the new repository will not have any object of its own, not even hardlinked, and it will transparently use the content of the original repository. There are caveats when working on a shared clone, but in this case they don't apply, as the clone is used just for building the site.
