### PR TITLE
Use Lua script to manage multi-language redirects

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "vendor/nginx-http-accept-lang"]
+	path = vendor/nginx-http-accept-lang
+	url = git@github.com:fghibellini/nginx-http-accept-lang

--- a/roles/common/tasks/file_system.yml
+++ b/roles/common/tasks/file_system.yml
@@ -4,3 +4,6 @@
 
 - name: Create Git bare repositories directory
   file: path=/home/ubuntu/repos state=directory group=coopdevs owner=ubuntu mode=2775
+
+- name: Create shared directory
+  file: path=/home/ubuntu/shared state=directory group=coopdevs owner=ubuntu mode=2775

--- a/roles/common/tasks/install_gems.yml
+++ b/roles/common/tasks/install_gems.yml
@@ -4,9 +4,11 @@
     name: bundler
     state: latest
     user_install: no
+    executable: "/usr/bin/gem2.3"
 
 - name: Install Jekyll gem
   gem:
     name: jekyll
     state: latest
     user_install: no
+    executable: "/usr/bin/gem2.3"

--- a/roles/common/tasks/ruby.yml
+++ b/roles/common/tasks/ruby.yml
@@ -1,8 +1,5 @@
 ---
-- name: Add BrightBox ruby ppa
-  apt_repository: repo=ppa:brightbox/ruby-ng state=present
-
-- name: Install BrightBox ruby 2.3 package
+- name: Install ruby 2.3 packages
   apt:
     name: "{{item}}"
     state: present

--- a/roles/coopdevs.org/files/coopdevs.conf
+++ b/roles/coopdevs.org/files/coopdevs.conf
@@ -4,8 +4,18 @@ server {
 
   server_name coopdevs.org www.coopdevs.org;
 
-  root /opt/sites/coopdevs;
-  index index.html;
+  # Initial i18n redirect
+  location = / {
+    default_type text/html;
 
-  expires 1d;
+    set $ngx_html_path $document_root;
+    content_by_lua_file /home/ubuntu/shared/nginx/lang.lua;
+  }
+
+  location / {
+    root /opt/sites/coopdevs;
+    index index.html;
+
+    expires 1d;
+  }
 }

--- a/roles/http-server/tasks/install_packages.yml
+++ b/roles/http-server/tasks/install_packages.yml
@@ -7,7 +7,7 @@
 
 - name: Install nginx package
   apt:
-    name: 'nginx'
+    name: 'nginx-extras'
     state: present
 
 - name: Add `www-data` user to `coopdevs` group

--- a/roles/http-server/tasks/main.yml
+++ b/roles/http-server/tasks/main.yml
@@ -6,6 +6,18 @@
     src: roles/http-server/files/nginx.conf
     dest: /etc/nginx/nginx.conf
 
+- name: Create shared nginx directory
+  file:
+    path: /home/ubuntu/shared/nginx
+    state: directory
+
+- name: Copy the lua lang module
+  notify: Reload NGINX
+  copy:
+    src: vendor/nginx-http-accept-lang/lang.lua
+    dest: /home/ubuntu/shared/nginx/lang.lua
+    mode: 'u+x'
+
 - name: Remove default nginx site
   file:
     path: /etc/nginx/sites-enabled/default


### PR DESCRIPTION
### WAT

One of the reasons we want to migrate our static pages to our own VPS is to have more control on how requests are managed. In this case we want to redirect requests to our (future) `/es`, `/ca` and `/en` URLs in order to show the correct language based on the `Accept-Language` header set by the browser.
### GIF

![](http://49.media.tumblr.com/0dea2f36b4f1967f054dc86224493f4d/tumblr_nhighcrDXm1qd4q8ao1_500.gif)
