### PR TITLE
Add SSL certificates for all domains

### DIFF
--- a/coopdevs.yml
+++ b/coopdevs.yml
@@ -45,3 +45,11 @@
         - limesurvey_user: limesurvey
         - limesurvey_group: limesurvey
     - role: discourse
+    - role: vendor/coopdevs.certbot_nginx
+      vars:
+        letsencrypt_email: info@coopdevs.org
+    - role: letsencrypt
+      vars:
+        domain_names:
+          - community.coopdevs.org
+          - forms.coopdevs.org

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -1,3 +1,5 @@
+- src: coopdevs.certbot_nginx
+  version: 0.0.3
 - src: geerlingguy.postgresql
   version: 1.3.1
 - src: geerlingguy.php

--- a/roles/discourse/templates/discourse_nginx.conf.j2
+++ b/roles/discourse/templates/discourse_nginx.conf.j2
@@ -1,12 +1,25 @@
 server {
-  listen 80;
-
+  listen 80; listen [::]:80;
   server_name {{ discourse_server_name }};
+
+  return 301 https://$host$request_uri;
+}
+
+server {
+  listen 443 ssl http2;
+  server_name {{ discourse_server_name }};
+
+  ssl_certificate /etc/letsencrypt/live/{{ discourse_server_name }}/fullchain.pem;
+  ssl_certificate_key /etc/letsencrypt/live/{{ discourse_server_name }}/privkey.pem;
+  include /etc/letsencrypt/options-ssl-nginx.conf;
+
+  gzip on;
 
   location / {
     proxy_pass http://unix:/var/discourse/shared/standalone/nginx.http.sock:;
     proxy_set_header Host $http_host;
     proxy_http_version 1.1;
+    proxy_set_header X-Forwarded-Proto $scheme;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
   }
 }

--- a/roles/letsencrypt/tasks/main.yml
+++ b/roles/letsencrypt/tasks/main.yml
@@ -1,0 +1,8 @@
+---
+- name: Install SSL certificates
+  include_role:
+    name: vendor/coopdevs.certbot_nginx
+    tasks_from: certificate.yml
+  with_items: "{{ domain_names }}"
+  loop_control:
+    loop_var: domain_name

--- a/roles/limesurvey/templates/limesurvey.conf.j2
+++ b/roles/limesurvey/templates/limesurvey.conf.j2
@@ -3,10 +3,24 @@ upstream php {
 }
 
 server {
-  listen   80;
+  listen 80; listen [::]:80;
+  server_name {{ limesurvey_server_name }};
+
+  return 301 https://$host$request_uri;
+}
+
+server {
+  listen 443 ssl http2;
+  server_name {{ limesurvey_server_name }};
+
+  ssl_certificate /etc/letsencrypt/live/{{ limesurvey_server_name }}/fullchain.pem;
+  ssl_certificate_key /etc/letsencrypt/live/{{ limesurvey_server_name }}/privkey.pem;
+  include /etc/letsencrypt/options-ssl-nginx.conf;
+
+  gzip on;
+
   root {{ limesurvey_dir }};
   index index.php index.html index.htm;
-  server_name {{ limesurvey_server_name }};
 
   location / {
     try_files $uri $uri/ =404;


### PR DESCRIPTION
Fix https://github.com/coopdevs/coopdevs-provisioning/issues/6

Depends on https://github.com/coopdevs/certbot_nginx/pull/10

 - [x] Install `certbot`
 - [x] Create and install certificates for all domains
 - [x] Add 443 Nginx configuration for community.coopdevs.org
 - [x] Add 443 Nginx configuration for forms.coopdevs.org
 - [x] Specify `certbot_nginx` version once https://github.com/coopdevs/certbot_nginx/pull/10 get merged